### PR TITLE
Feature/support explicit c64 debugger start address

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This extension contributes the following settings:
 - `kickass-c64.javaBin`: Full path to java binary
 - `kickass-c64.viceBin`: Full path to VICE binary
 - `kickass-c64.useC64Debugger`: Debug with C64 Debugger
+- `kickass-c64.useC64DebuggerStartAddress`: Make C64 Debugger jump to a specific address when started
 - `kickass-c64.c64DebuggerBin`: Full path to C64 Debugger binary
 
 ## Known Issues

--- a/package.json
+++ b/package.json
@@ -121,7 +121,27 @@
           "description": "Full path to C64 Debugger binary"
         }
       }
-    }
+    },
+    "keybindings": [
+      {
+        "command": "kickass-c64.build",
+        "key": "win+b",
+        "mac": "cmd+b",
+        "when": "editorLangId == kickassembler"
+      },
+      {
+        "command": "kickass-c64.build-run",
+        "key": "ctrl+F5",
+        "mac": "ctrl+F5",
+        "when": "editorLangId == kickassembler"
+      },
+      {
+        "command": "kickass-c64.build-debug",
+        "key": "f5",
+        "mac": "f5",
+        "when": "editorLangId == kickassembler"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "cd client && npm run update-vscode && cd ..",

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "keybindings": [
       {
         "command": "kickass-c64.build",
-        "key": "win+b",
-        "mac": "cmd+b",
+        "key": "shift+ctrl+b",
+        "mac": "shift+cmd+b",
         "when": "editorLangId == kickassembler"
       },
       {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
           "default": true,
           "description": "Debug with C64 Debugger"
         },
+        "kickass-c64.useC64DebuggerStartAddress": {
+          "type": "string",
+          "default": "",
+          "description": "An explicit hex address that C64Debugger will jump to when started.\nC64Debugger will use -autojmp when the C64DebuggerStartAddress is empty.\nSample value: x4000"
+        },
         "kickass-c64.c64DebuggerBin": {
           "type": "string",
           "default": "/Applications/C64\\ Debugger.app/Contents/MacOS/C64Debugger",


### PR DESCRIPTION
**TLDR;** New optional feature to use a specific C64Debugger jump address

**When is this useful**
1. c64Debugger does not jump to the expected location when -autojmp is used.
2. When you want to debug a specific part of your loaded assembly code.

**Usage**
Provide a specific address value in the setting named  `C64 Debugger Start Address`

**Default behavior**
The vscode-kickass-c64 extension uses -autojmp when invoking C64Debugger. (_no change_)

**New alternate behavior**
With a specific memory address in `C64 Debugger Start Address` this extension now invokes C64Debugger with -jmp <_address_>

**Error handling**
Any provided start address is validated before use. Default behavior (_-autojmp_) is used if the provided address is considered invalid. To be considered valid the value must be prefixed with x and have a value within the commodore 64 memory range (0000-FFFF).
reference: [https://www.c64-wiki.com/wiki/Memory_Map](https://www.c64-wiki.com/wiki/Memory_Map)