### PR TITLE
Use full paths for arguments to Vice

### DIFF
--- a/client/commands/run.js
+++ b/client/commands/run.js
@@ -21,9 +21,10 @@ module.exports = function run({ outputFile, outputDir, debug }) {
     const debugArgs = debug ? ["-debuginfo", replaceFileExtension(outputFile, ".dbg")] : [];
     spawn(config.c64DebuggerBin, [layoutArg, ...debugArgs, ...args], spawnOptions);
   } else {
-    const logfile = `${path.basename(outputFile)}-vice.log`;
+    const logfile = path.join(outputDir, `${path.basename(outputFile)}-vice.log`);
     const args = ["-logfile", logfile];
-    const debugArgs = debug ? ["-moncommands", replaceFileExtension(outputFile, ".vs")] : [];
-    spawn(config.viceBin, [...args, ...debugArgs, outputFile], spawnOptions);
+    const debugArgs = debug ? ["-moncommands", path.join(outputDir, replaceFileExtension(outputFile, ".vs"))] : [];
+    const fullOutputFile = path.join(outputDir, outputFile);
+    spawn(config.viceBin, [...args, ...debugArgs, fullOutputFile], spawnOptions);
   }
 };

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.28.0"
+    "vscode": "^1.78.0"
   },
   "scripts": {},
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -8,10 +8,7 @@
   "engines": {
     "vscode": "^1.28.0"
   },
-  "scripts": {
-    "update-vscode": "vscode-install",
-    "postinstall": "vscode-install"
-  },
+  "scripts": {},
   "devDependencies": {
     "vscode": "^1.1.36"
   },


### PR DESCRIPTION
Vice 3.5 and newer on macOS requires full paths for arguments. This PR should fix this. Plus a few updates of dependencies and extension stuff.