### PR TITLE
Fix vs-file argument for Vice when using "file-to-run" annotation

### DIFF
--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -16,6 +16,7 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
   const currentFile = vscode.window.activeTextEditor.document.fileName;
   const fileToCompile = (useStartUp && findStartUp(currentFile)) || currentFile;
   const defaultOutputFile = replaceFileExtension(fileToCompile, ".prg");
+  const defaultOutputFileName = replaceFileExtension(fileToCompile, "");
   const workDir = path.dirname(fileToCompile);
   const outputDir = path.join(workDir, outDir);
   const buildLog = path.join(outputDir, "buildlog.txt");
@@ -49,6 +50,7 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
     outputFile,
     outputDir,
     debug,
+    defaultOutputFileName,
   };
 };
 

--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -16,7 +16,6 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
   const currentFile = vscode.window.activeTextEditor.document.fileName;
   const fileToCompile = (useStartUp && findStartUp(currentFile)) || currentFile;
   const defaultOutputFile = replaceFileExtension(fileToCompile, ".prg");
-  const defaultOutputFileName = replaceFileExtension(fileToCompile, "");
   const workDir = path.dirname(fileToCompile);
   const outputDir = path.join(workDir, outDir);
   const buildLog = path.join(outputDir, "buildlog.txt");
@@ -47,10 +46,10 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
   }
 
   return {
+    fileToCompile,
     outputFile,
     outputDir,
     debug,
-    defaultOutputFileName,
   };
 };
 

--- a/client/commands/run.js
+++ b/client/commands/run.js
@@ -4,7 +4,7 @@ const path = require("path");
 const { spawn } = require("../process");
 const { getConfig, replaceFileExtension } = require("../util");
 
-module.exports = function run({ outputFile, outputDir, debug }) {
+module.exports = function run({ outputFile, outputDir, debug, defaultOutputFileName }) {
   const config = getConfig();
   if (!outputFile || !outputDir) return;
 
@@ -23,7 +23,7 @@ module.exports = function run({ outputFile, outputDir, debug }) {
   } else {
     const logfile = path.join(outputDir, `${path.basename(outputFile)}-vice.log`);
     const args = ["-logfile", logfile];
-    const debugArgs = debug ? ["-moncommands", path.join(outputDir, replaceFileExtension(outputFile, ".vs"))] : [];
+    const debugArgs = debug ? ["-moncommands", path.join(outputDir, `${defaultOutputFileName}.vs`)] : [];
     const fullOutputFile = path.join(outputDir, outputFile);
     spawn(config.viceBin, [...args, ...debugArgs, fullOutputFile], spawnOptions);
   }

--- a/client/commands/run.js
+++ b/client/commands/run.js
@@ -4,7 +4,7 @@ const path = require("path");
 const { spawn } = require("../process");
 const { getConfig, replaceFileExtension } = require("../util");
 
-module.exports = function run({ outputFile, outputDir, debug, defaultOutputFileName }) {
+module.exports = function run({ fileToCompile, outputFile, outputDir, debug }) {
   const config = getConfig();
   if (!outputFile || !outputDir) return;
 
@@ -23,7 +23,7 @@ module.exports = function run({ outputFile, outputDir, debug, defaultOutputFileN
   } else {
     const logfile = path.join(outputDir, `${path.basename(outputFile)}-vice.log`);
     const args = ["-logfile", logfile];
-    const debugArgs = debug ? ["-moncommands", path.join(outputDir, `${defaultOutputFileName}.vs`)] : [];
+    const debugArgs = debug ? ["-moncommands", path.join(outputDir, replaceFileExtension(fileToCompile, ".vs"))] : [];
     const fullOutputFile = path.join(outputDir, outputFile);
     spawn(config.viceBin, [...args, ...debugArgs, fullOutputFile], spawnOptions);
   }


### PR DESCRIPTION
Use original filename for vice vs-file. Since the vs-file cannot be named when compiling, it will always have the same name as the source file.

Test with this code:
```
// @kickass-build "file-to-run": "StartupSegment.prg"

.segment Startup [outPrg="StartupSegment.prg"]
:BasicUpstart2(startup)
startup:
.break
inc $d020
jmp *-3

.segment Another [outPrg="AnotherSegment.prg"]
:BasicUpstart2(another)
another:
.break
inc $d021
jmp *-3
```

Start in Vice with debugging.
* Make sure Vice starts
* Make sure breakpoints are hit
* Test both segments.