### PR TITLE
Fix/fix accidental output window compile

### DIFF
--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -8,6 +8,12 @@ const output = require("../output");
 const { getConfig, replaceFileExtension } = require("../util");
 
 module.exports = function compile({ debug = false, useStartUp = false } = {}) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.uri.scheme !== "file") {
+    vscode.window.showErrorMessage("Please activate a file tab to use this command.");
+    return {};
+  }
+
   const config = getConfig();
   output.clear();
   output.show();

--- a/client/commands/run.js
+++ b/client/commands/run.js
@@ -1,10 +1,17 @@
 "use strict";
+const vscode = require("vscode");
 const path = require("path");
 
 const { spawn } = require("../process");
 const { getConfig, replaceFileExtension } = require("../util");
 
 module.exports = function run({ fileToCompile, outputFile, outputDir, debug }) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.uri.scheme !== "file") {
+    vscode.window.showErrorMessage("Please activate a file tab to use this command.");
+    return;
+  }
+
   const config = getConfig();
   if (!outputFile || !outputDir) return;
 

--- a/client/output.js
+++ b/client/output.js
@@ -7,7 +7,7 @@ module.exports = {
   append: (value) => output().append(value),
   appendLine: (value) => output().appendLine(value),
   clear: () => output().clear(),
-  show: () => output().show(),
+  show: () => output().show(true),
 };
 
 function output() {


### PR DESCRIPTION
Sometimes (randomly) the output window will get focused when compiling. Attempting to compile again gives something like:
```
Compiling extension-output-CaptainJiNX.kickass-c64-#1-Kick Assembler (C64)

Child process spawnSync: java -jar /Applications/KickAssembler/KickAss.jar -odir bin -log bin/buildlog.txt -showmem extension-output-CaptainJiNX.kickass-c64-#1-Kick Assembler (C64)

//------------------------------------------------------
//------------------------------------------------------
//         Kick Assembler v5.25 by Mads Nielsen         
//------------------------------------------------------
//------------------------------------------------------
Couldn't create log : bin/buildlog.txt (Operation not permitted)
Error: Inputfile 'extension-output-CaptainJiNX.kickass-c64-#1-Kick Assembler (C64)' doesn't exist.
```

This PR makes it less likely that the output window gets focus after build, and also shows an error message when trying to compile something that is not a normal file tab.