### PR TITLE
Add "additional class path" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This extension contributes the following settings:
 - `kickass-c64.c64DebuggerBin`: Full path to C64 Debugger binary
 - `kickass-c64.runWithC64Debugger`: Run with C64 Debugger
 - `kickass-c64.debugWithC64Debugger`: Debug with C64 Debugger
+- `kickass-c64.kickAssAdditionalClassPath`: Additional java classpath, useful for Kick Assembler plugin jar files
 
 ## Known Issues
 

--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -35,7 +35,7 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
   output.appendLine(`Compiling ${fileToCompile}`);
 
   const debugArgs = debug ? [config.debugWithC64Debugger ? "-debugdump" : "-vicesymbols"] : [];
-  const args = ["-jar", config.kickAssJar, "-odir", outDir, "-log", buildLog, "-showmem"];
+  const args = ["-cp", config.kickAssJar, "kickass.KickAssembler", "-odir", outDir, "-log", buildLog, "-showmem"];
   const process = spawnSync(config.javaBin, [...args, ...debugArgs, fileToCompile], { cwd: workDir });
   output.append(process.stdout.toString());
 

--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -35,7 +35,16 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
   output.appendLine(`Compiling ${fileToCompile}`);
 
   const debugArgs = debug ? [config.debugWithC64Debugger ? "-debugdump" : "-vicesymbols"] : [];
-  const args = ["-cp", config.kickAssJar, "kickass.KickAssembler", "-odir", outDir, "-log", buildLog, "-showmem"];
+  const args = [
+    "-cp",
+    `${config.kickAssJar}:${config.kickAssAdditionalClassPath}`,
+    "kickass.KickAssembler",
+    "-odir",
+    outDir,
+    "-log",
+    buildLog,
+    "-showmem",
+  ];
   const process = spawnSync(config.javaBin, [...args, ...debugArgs, fileToCompile], { cwd: workDir });
   output.append(process.stdout.toString());
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
           "type": "boolean",
           "default": true,
           "description": "Empty bin folder before build"
+        },
+        "kickass-c64.kickAssAdditionalClassPath": {
+          "type": "string",
+          "default": "",
+          "description": "Additional java classpath, useful for Kick Assembler plugin jar files"
         }
       }
     },

--- a/server/server.js
+++ b/server/server.js
@@ -98,7 +98,7 @@ async function getKickAssembler5AsmInfo(document) {
       settings.javaBin,
       [
         "-cp",
-        settings.kickAssJar,
+        `${settings.kickAssJar}:${settings.kickAssAdditionalClassPath}`,
         "kickass.KickAssembler",
         fileName,
         "-noeval",
@@ -137,7 +137,7 @@ async function getKickAssembler4AsmInfo(document) {
       settings.javaBin,
       [
         "-cp",
-        `${settings.kickAssJar}:${kickassRunnerJar}`,
+        `${settings.kickAssJar}:${kickassRunnerJar}:${settings.kickAssAdditionalClassPath}`,
         "com.noice.kickass.KickAssRunner",
         fileName,
         "-asminfo",

--- a/server/server.js
+++ b/server/server.js
@@ -97,8 +97,9 @@ async function getKickAssembler5AsmInfo(document) {
     const proc = spawn(
       settings.javaBin,
       [
-        "-jar",
-        `${settings.kickAssJar}`,
+        "-cp",
+        settings.kickAssJar,
+        "kickass.KickAssembler",
         fileName,
         "-noeval",
         "-asminfo",


### PR DESCRIPTION
Adds a setting to set additional class path. Very useful when working with Kick Assembler plugins.