### PR TITLE
Bug/Fixed classpath delimiter issue.

### DIFF
--- a/client/commands/compile.js
+++ b/client/commands/compile.js
@@ -40,10 +40,16 @@ module.exports = function compile({ debug = false, useStartUp = false } = {}) {
 
   output.appendLine(`Compiling ${fileToCompile}`);
 
+  const classpath = [
+    config.kickAssJar,
+    config.kickAssAdditionalClassPath]
+    .filter(Boolean)
+    .join(path.delimiter);
+
   const debugArgs = debug ? [config.debugWithC64Debugger ? "-debugdump" : "-vicesymbols"] : [];
   const args = [
     "-cp",
-    `${config.kickAssJar}:${config.kickAssAdditionalClassPath}`,
+    classpath,
     "kickass.KickAssembler",
     "-odir",
     outDir,

--- a/server/server.js
+++ b/server/server.js
@@ -42,7 +42,7 @@ connection.onInitialized(() => {
 documents.onDidClose((e) => {
   const fileName = URI.parse(e.document.uri).fsPath;
   const documentTempFilePath = getDocumentTempFilePath(fileName);
-  fs.unlink(documentTempFilePath, () => { });
+  fs.unlink(documentTempFilePath, () => {});
 });
 
 documents.onDidChangeContent((change) => {

--- a/server/server.js
+++ b/server/server.js
@@ -42,7 +42,7 @@ connection.onInitialized(() => {
 documents.onDidClose((e) => {
   const fileName = URI.parse(e.document.uri).fsPath;
   const documentTempFilePath = getDocumentTempFilePath(fileName);
-  fs.unlink(documentTempFilePath, () => {});
+  fs.unlink(documentTempFilePath, () => { });
 });
 
 documents.onDidChangeContent((change) => {
@@ -94,11 +94,19 @@ async function getKickAssembler5AsmInfo(document) {
   return new Promise((resolve) => {
     let output = "";
 
+    // Use the correct classpath delimiter for the current OS
+    const classpath = [
+      settings.kickAssJar,
+      settings.kickAssAdditionalClassPath
+    ]
+      .filter(Boolean)
+      .join(path.delimiter);
+
     const proc = spawn(
       settings.javaBin,
       [
         "-cp",
-        `${settings.kickAssJar}:${settings.kickAssAdditionalClassPath}`,
+        classpath,
         "kickass.KickAssembler",
         fileName,
         "-noeval",

--- a/server/server.js
+++ b/server/server.js
@@ -42,7 +42,7 @@ connection.onInitialized(() => {
 documents.onDidClose((e) => {
   const fileName = URI.parse(e.document.uri).fsPath;
   const documentTempFilePath = getDocumentTempFilePath(fileName);
-  fs.unlink(documentTempFilePath, () => {});
+  fs.unlink(documentTempFilePath, () => { });
 });
 
 documents.onDidChangeContent((change) => {
@@ -94,11 +94,9 @@ async function getKickAssembler5AsmInfo(document) {
   return new Promise((resolve) => {
     let output = "";
 
-    // Use the correct classpath delimiter for the current OS
     const classpath = [
       settings.kickAssJar,
-      settings.kickAssAdditionalClassPath
-    ]
+      settings.kickAssAdditionalClassPath]
       .filter(Boolean)
       .join(path.delimiter);
 
@@ -141,11 +139,18 @@ async function getKickAssembler4AsmInfo(document) {
   return await new Promise((resolve) => {
     let output = "";
 
+    const classpath = [
+      settings.kickAssJar,
+      kickassRunnerJar,
+      settings.kickAssAdditionalClassPath]
+      .filter(Boolean)
+      .join(path.delimiter);
+
     const proc = spawn(
       settings.javaBin,
       [
         "-cp",
-        `${settings.kickAssJar}:${kickassRunnerJar}:${settings.kickAssAdditionalClassPath}`,
+        classpath,
         "com.noice.kickass.KickAssRunner",
         fileName,
         "-asminfo",


### PR DESCRIPTION
As explained in the [issue ](https://github.com/CaptainJiNX/vscode-kickass-c64/issues/39) path delimiter differs by OS, and the default ":" was causing classpath issues on Windows. This change fixes that issue by using the right delimiter in the classpath string.

Reviewer: @CaptainJiNX 